### PR TITLE
Add renovate bot to keep kops up to date

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,0 +1,61 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended",
+    ":gitSignOff",
+    "helpers:pinGitHubActionDigests"
+  ],
+  // This ensures that the gitAuthor and gitSignOff fields match
+  "gitAuthor": "renovate[bot] <bot@renovateapp.com>",
+  "includePaths": [
+    "**/action.yaml"
+  ],
+  "pinDigests": true,
+  "ignorePresets": [":prHourlyLimit2"],
+  "separateMajorMinor": true,
+  "separateMultipleMajor": true,
+  "separateMinorPatch": true,
+  "pruneStaleBranches": true,
+  "baseBranches": [
+    "main"
+  ],
+  "vulnerabilityAlerts": {
+    "enabled": true
+  },
+  "labels": [
+    "dependencies",
+    "renovate/stop-updating"
+  ],
+  "stopUpdatingLabel": "renovate/stop-updating",
+  "packageRules": [
+    {
+      "groupName": "all github action dependencies",
+      "groupSlug": "all-github-action",
+      "matchFileNames": [
+        "**/action.yaml"
+      ],
+      "matchUpdateTypes": [
+        "major",
+        "minor",
+        "digest",
+        "patch",
+        "pin",
+        "pinDigest"
+      ]
+    }
+  ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "fileMatch": [
+        "action\\.yaml$",
+      ],
+      // This regex manages version strings in GitHub actions files,
+      // similar to the examples shown here:
+      //   https://docs.renovatebot.com/modules/manager/regex/#advanced-capture
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)\\s+.+default: \"(?<currentValue>.*)\""
+      ]
+    }
+  ]
+}

--- a/install-kops/action.yaml
+++ b/install-kops/action.yaml
@@ -4,6 +4,7 @@ inputs:
   release_version:
     description: "version of kops"
     required: true
+    # renovate: datasource=github-releases depName=kubernetes/kops
     default: "v1.29.0-alpha.2"
 runs:
   using: "composite"


### PR DESCRIPTION
This commit adds a configuration for renovate, based on the configurations found in cilium/little-vm-helper and cilium/cilium, and modifies the install-kops action to keep the kops version up to date.

PR #4 can be closed in favor of this, as PR #4 is an automated PR opened by the renovate bot to add a basic configuration.