### PR TITLE
Update create-cluster for 5k nodes scale test

### DIFF
--- a/create-cluster/action.yaml
+++ b/create-cluster/action.yaml
@@ -19,6 +19,9 @@ inputs:
   node_count:
     description: "Number of nodes"
     required: true
+  allocate_node_cidrs:
+    description: "Whether to enable KCM to allocate per-node CIDRs. If enabled, CIDRs will be allocated from those provided in `node_cidr`"
+    default: "true"
   node_cidr:
     description: "The set of IP addresses assigned to nodes"
     default: "10.16.0.0/16"
@@ -70,6 +73,7 @@ runs:
           --set spec.kubeControllerManager.endpointSliceUpdatesBatchPeriod=500ms \
           --set spec.kubeControllerManager.kubeAPIQPS=100 \
           --set spec.kubeControllerManager.kubeAPIBurst=100 \
+          --set spec.kubeControllerManager.allocateNodeCIDRs=${{ inputs.allocate_node_cidrs }} \
           --set spec.kubeScheduler.kubeAPIQPS=500 \
           --set spec.kubeScheduler.kubeAPIBurst=500 \
           --yes

--- a/create-cluster/action.yaml
+++ b/create-cluster/action.yaml
@@ -56,6 +56,14 @@ runs:
           --set spec.kubeScheduler.authorizationAlwaysAllowPaths=/metrics \
           --set spec.kubeScheduler.authorizationAlwaysAllowPaths=/healthz \
           --set spec.kubeProxy.enabled=${{ inputs.kube_proxy_enabled }} \
+          --set spec.kubeAPIServer.maxRequestsInflight=800 \
+          --set spec.kubeAPIServer.maxMutatingRequestsInflight=400 \
+          --set spec.kubeControllerManager.endpointUpdatesBatchPeriod=500ms \
+          --set spec.kubeControllerManager.endpointSliceUpdatesBatchPeriod=500ms \
+          --set spec.kubeControllerManager.kubeAPIQPS=100 \
+          --set spec.kubeControllerManager.kubeAPIBurst=100 \
+          --set spec.kubeScheduler.kubeAPIQPS=500 \
+          --set spec.kubeScheduler.kubeAPIBurst=500 \
           --yes
 
     - name: Dump cluster config

--- a/create-cluster/action.yaml
+++ b/create-cluster/action.yaml
@@ -10,6 +10,9 @@ inputs:
   control_plane_count:
     description: "Number of control plane nodes"
     required: true
+  control_plane_volume_size:
+    description: "Size of the root volume deployed for control plane nodes"
+    default: "50"
   node_size:
     description: "Node size"
     required: true
@@ -19,6 +22,9 @@ inputs:
   node_cidr:
     description: "The set of IP addresses assigned to nodes"
     default: "10.16.0.0/16"
+  node_volume_size:
+    description: "Size of the root volume deployed for nodes"
+    default: "50"
   kops_state:
     description: "Bucket where to store kops state"
     required: true
@@ -41,8 +47,10 @@ runs:
           --project=${{ inputs.project_id }} \
           --control-plane-count ${{ inputs.control_plane_count }} \
           --control-plane-size ${{ inputs.control_plane_size }} \
+          --control-plane-volume-size ${{ inputs.control_plane_volume_size }} \
           --node-count ${{ inputs.node_count }} \
           --node-size ${{ inputs.node_size }} \
+          --node-volume-size ${{ inputs.node_volume_size }} \
           --networking cni \
           --set spec.kubeAPIServer.anonymousAuth=true \
           --set spec.networking.subnets[0].cidr=${{ inputs.node_cidr }} \


### PR DESCRIPTION
Tunes the create-cluster action to handle large scale clusters:
- Decrease QPS on KCM to 100
- Increase QPS for kube-scheduler to 500
- Reduce default size of node volumes and allow configuration
- Allow disabling KCM node CIDR allocation

Related: https://github.com/cilium/cilium/pull/32800