### PR TITLE
Add notice with build info and export dir

### DIFF
--- a/export-results/action.yaml
+++ b/export-results/action.yaml
@@ -24,5 +24,7 @@ runs:
         # BUILD_ID needs to be an integer
         BUILD_ID="$(date +%s)"
         EXPORT_DIR="${{ inputs.results_bucket }}/logs/${{ inputs.test_name }}-${{ github.ref_name }}/${BUILD_ID}"
+        echo "::notice::BUILD_ID: $BUILD_ID"
+        echo "::notice::EXPORT_DIR: $EXPORT_DIR"
         gsutil -m cp -R ${{ inputs.artifacts }} $EXPORT_DIR/artifacts/
         gsutil -m cp sha.txt run-url.txt ${{ inputs.other_files }} $EXPORT_DIR/


### PR DESCRIPTION
Example runs:
https://github.com/cilium/cilium/actions/runs/9547197617
https://github.com/cilium/cilium/actions/runs/9547197617

This helps with checking perfdash visualization and locating pprofs/sysdumps etc. 