### PR TITLE
Make kube proxy and node CIDR configurable in create-cluster action

### DIFF
--- a/create-cluster/action.yaml
+++ b/create-cluster/action.yaml
@@ -16,6 +16,9 @@ inputs:
   node_count:
     description: "Number of nodes"
     required: true
+  node_cidr:
+    description: "The set of IP addresses assigned to nodes"
+    default: "10.16.0.0/16"
   kops_state:
     description: "Bucket where to store kops state"
     required: true
@@ -42,7 +45,7 @@ runs:
           --node-size ${{ inputs.node_size }} \
           --networking cni \
           --set spec.kubeAPIServer.anonymousAuth=true \
-          --set spec.networking.subnets[0].cidr=10.16.0.0/16 \
+          --set spec.networking.subnets[0].cidr=${{ inputs.node_cidr }} \
           --set spec.etcdClusters[0].manager.listenMetricsURLs=http://localhost:2382 \
           --set spec.kubeAPIServer.enableContentionProfiling=true \
           --set spec.kubeAPIServer.enableProfiling=true \

--- a/create-cluster/action.yaml
+++ b/create-cluster/action.yaml
@@ -22,6 +22,9 @@ inputs:
   project_id:
     description: "GCP Project in which to create cluster"
     required: true
+  kube_proxy_enabled:
+    description: "Whether to enable the deployment of Kube Proxy"
+    default: "true"
 runs:
   using: "composite"
   steps:
@@ -49,6 +52,7 @@ runs:
           --set spec.kubeScheduler.enableProfiling=true \
           --set spec.kubeScheduler.authorizationAlwaysAllowPaths=/metrics \
           --set spec.kubeScheduler.authorizationAlwaysAllowPaths=/healthz \
+          --set spec.kubeProxy.enabled=${{ inputs.kube_proxy_enabled }} \
           --yes
 
     - name: Dump cluster config


### PR DESCRIPTION
In both cases, the default value matches the previous setting, to avoid introducing any differences in case they are not configured. 