### PR TITLE
Bump kops version to v1.29.0

### DIFF
--- a/install-kops/action.yaml
+++ b/install-kops/action.yaml
@@ -5,7 +5,7 @@ inputs:
     description: "version of kops"
     required: true
     # renovate: datasource=github-releases depName=kubernetes/kops
-    default: "v1.29.0-alpha.2"
+    default: "v1.29.0"
 runs:
   using: "composite"
   steps:


### PR DESCRIPTION
Although 238d773 ("Add renovate bot to keep kops up to date") enabled renovate to automatically bump the kops version, it appears that renovate doesn't automatically bump it if configured to a pre-release version. Hence, let's manually update it to the latest stable version, so that subsequent updates can than be performed automatically.