### PR TITLE
Updates for testing at 5k nodes

### DIFF
--- a/cleanup-cluster/action.yaml
+++ b/cleanup-cluster/action.yaml
@@ -11,8 +11,12 @@ runs:
   using: "composite"
   steps:
     - name: Delete cluster
-      shell: bash
-      run: |
+      uses: nick-fields/retry@7152eba30c6575329ac0576536151aca5a72780e # v3.0.0
+      with:
+        timeout_minutes: 30
+        max_attempts: 10
+        polling_interval_seconds: 120
+        command: |
           ./kops delete cluster \
             ${{ inputs.cluster_name }} \
             --state ${{ inputs.kops_state }} \

--- a/create-cluster/action.yaml
+++ b/create-cluster/action.yaml
@@ -58,6 +58,8 @@ runs:
           --set spec.kubeAPIServer.anonymousAuth=true \
           --set spec.networking.subnets[0].cidr=${{ inputs.node_cidr }} \
           --set spec.etcdClusters[0].manager.listenMetricsURLs=http://localhost:2382 \
+          --set spec.etcdClusters[*].etcdMembers[*].volumeSize=50 \
+          --set spec.etcdClusters[*].manager.env=ETCD_QUOTA_BACKEND_BYTES=8589934592 \
           --set spec.kubeAPIServer.enableContentionProfiling=true \
           --set spec.kubeAPIServer.enableProfiling=true \
           --set spec.kubeControllerManager.enableContentionProfiling=true \

--- a/create-instance-group/action.yaml
+++ b/create-instance-group/action.yaml
@@ -16,6 +16,9 @@ inputs:
   ig_name:
     description: "Name of instanceGroup"
     required: true
+  node_volume_size:
+    description: "Size of the root volume deployed for nodes"
+    default: "50"
 runs:
   using: "composite"
   steps:
@@ -39,6 +42,7 @@ runs:
             --set spec.maxSize=${{ inputs.node_count }} \
             --set spec.minSize=${{ inputs.node_count }} \
             --set spec.machineType=${{ inputs.node_size }} \
+            --set spec.rootVolume.size=${{ inputs.node_volume_size }} \
             --unset spec.zones \
             --set spec.zones=us-west1-a
 

--- a/delete-instance-group/action.yaml
+++ b/delete-instance-group/action.yaml
@@ -1,0 +1,23 @@
+name: "Delete instance group"
+description: "Workflow that deletes a kops instance group"
+inputs:
+  instance_group_name:
+    description: "Name of the instance group to delete"
+    required: true
+  kops_state:
+    description: "Bucket with kops state"
+    required: true
+runs:
+  using: "composite"
+  steps:
+    - name: Delete instance group with retry
+      uses: nick-fields/retry@7152eba30c6575329ac0576536151aca5a72780e # v3.0.0
+      with:
+        timeout_minutes: 30
+        max_attempts: 10
+        polling_interval_seconds: 120
+        command: |
+          ./kops delete instancegroup \
+            ${{ inputs.instance_group_name }} \
+            --state ${{ inputs.kops_state }} \
+            --yes

--- a/validate-cluster/action.yaml
+++ b/validate-cluster/action.yaml
@@ -7,6 +7,9 @@ inputs:
   kops_state:
     description: "Bucket with kops state"
     required: true
+  timeout:
+    description: "Maximum time to wait for cluster to be ready"
+    default: "20m"
 runs:
   using: "composite"
   steps:
@@ -16,5 +19,5 @@ runs:
         ./kops validate cluster \
           ${{ inputs.cluster_name }} \
           --state ${{ inputs.kops_state }} \
-          --wait 20m \
+          --wait ${{ inputs.timeout }} \
           --count 3


### PR DESCRIPTION
This is a collection of updates/additions to get us closer to 5k nodes scale test:
- Allow configuration of node volume size and sets default to 50GB to reduce costs.
- Add configurable timeout to validate-cluster
- Increase etcd backend quota to 8gb and volume size from 20gb -> 50gb
- Add a separate action to delete instance groups with retry
- Add retry to cluster-cleanup