### PR TITLE
validate-cluster: add config option for interval

### DIFF
--- a/validate-cluster/action.yaml
+++ b/validate-cluster/action.yaml
@@ -10,6 +10,9 @@ inputs:
   timeout:
     description: "Maximum time to wait for cluster to be ready"
     default: "20m"
+  interval:
+    description: "Time to wait between validation attempts"
+    default: "60s"
 runs:
   using: "composite"
   steps:
@@ -20,4 +23,5 @@ runs:
           ${{ inputs.cluster_name }} \
           --state ${{ inputs.kops_state }} \
           --wait ${{ inputs.timeout }} \
+          --interval ${{ inputs.interval }} \
           --count 3


### PR DESCRIPTION
Allow configuring the wait interval between validation attempts. This can help reduce API usage and avoid failures due to rate-limiting.

The default is 10s, preserving the current behavior.