### PR TITLE
create-cluster: allow configuring etcd volume size

### DIFF
--- a/create-cluster/action.yaml
+++ b/create-cluster/action.yaml
@@ -37,6 +37,9 @@ inputs:
   kube_proxy_enabled:
     description: "Whether to enable the deployment of Kube Proxy"
     default: "true"
+  etcd_volume_size:
+    description: "Size of the volumes deployed for the etcd clusters"
+    default: "50"
 runs:
   using: "composite"
   steps:
@@ -58,7 +61,7 @@ runs:
           --set spec.kubeAPIServer.anonymousAuth=true \
           --set spec.networking.subnets[0].cidr=${{ inputs.node_cidr }} \
           --set spec.etcdClusters[0].manager.listenMetricsURLs=http://localhost:2382 \
-          --set spec.etcdClusters[*].etcdMembers[*].volumeSize=50 \
+          --set spec.etcdClusters[*].etcdMembers[*].volumeSize=${{ inputs.etcd_volume_size }} \
           --set spec.etcdClusters[*].manager.env=ETCD_QUOTA_BACKEND_BYTES=8589934592 \
           --set spec.kubeAPIServer.enableContentionProfiling=true \
           --set spec.kubeAPIServer.enableProfiling=true \


### PR DESCRIPTION
The size of a GCE pd volume determines its IOPS. At 50gb the volume can attain 1500 IOPS. The etcd clusters in the large scale-test were encountering problems due to slow disk speeds. This will allow increasing the volume size to 500gb, allowing the maximum throughput available at 15,000 IOPS.