### PR TITLE
setup-firewall: allow to skip native routing rule

### DIFF
--- a/setup-firewall/action.yaml
+++ b/setup-firewall/action.yaml
@@ -4,6 +4,10 @@ inputs:
   cluster_name:
     description: "Name of the target cluster to adjust to rules for"
     required: true
+  create_native_routing_firewall:
+    description: "Whether to create a custom firewall rule for native routing traffic"
+    default: 'true'
+    required: false
 runs:
   using: "composite"
   steps:
@@ -23,6 +27,7 @@ runs:
         # running in prod.
 
     - name: Create custom firewall rule for native routing traffic
+      if: ${{ inputs.create_native_routing_firewall == 'true' }}
       shell: bash
       run: |
         # Required to allow pod to remote pod/node traffic when Cilium


### PR DESCRIPTION
This is required in case of having multiple node pools as kops is reseting firewall updated in the first step.
Trying to run setup-firewall multiple times resulted in failure due to already exisitng firewall rule.