### PR TITLE
setup-firewall: truncate rule name prefix up to 61 characters

### DIFF
--- a/cleanup-cluster/action.yaml
+++ b/cleanup-cluster/action.yaml
@@ -17,7 +17,7 @@ runs:
         max_attempts: 10
         polling_interval_seconds: 120
         command: |
-          NAME="pod-cidrs-to-node-${{ inputs.cluster_name }}"
+          NAME="pods-to-node-${{ inputs.cluster_name }}"
           NAME="${NAME//./-}"
 
           if gcloud compute firewall-rules describe ${NAME} >/dev/null 2>&1; then

--- a/setup-firewall/action.yaml
+++ b/setup-firewall/action.yaml
@@ -41,7 +41,7 @@ runs:
         NETWORK="${NETWORK//./-}"
 
         gcloud compute firewall-rules create \
-          pod-cidrs-to-node-${NETWORK} \
+          pods-to-node-${NETWORK} \
           --allow tcp,udp,icmp,esp,ah,sctp \
           --network=${NETWORK} \
           --direction=INGRESS \


### PR DESCRIPTION
We recently observed the following error when running a scale test:

`Invalid value for field 'resource.name': 'pod-cidrs-to-node-${{ test_name }}-${{ github.run_id }}-${{ github.run_attempt }}-${{ cluster_name }}'. Must be a match of regex '(?:[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?)'`

In particular, the firewall rule name achieved had length=65, which is more than the allowed by the gcloud sdk (61 characters). Let's shrink the name of the rules by starting truncating the prefix if needed. This should give us enough room to preserve the randomness in the provided input name, which, in our case, was given by the `github.run_id` variable within the cluster_name.

We'd better start from the prefix to prune, since there are more characters than in the suffix and it's always fixed/known.