### PR TITLE
Make disk type configurable

### DIFF
--- a/create-cluster/action.yaml
+++ b/create-cluster/action.yaml
@@ -71,6 +71,7 @@ runs:
           --set spec.kubeAPIServer.anonymousAuth=true \
           --set spec.networking.subnets[0].cidr=${{ inputs.node_cidr }} \
           --set spec.etcdClusters[0].manager.listenMetricsURLs=http://localhost:2382 \
+          --set spec.etcdClusters[*].etcdMembers[*].volumeType=pd-ssd \
           --set spec.etcdClusters[*].etcdMembers[*].volumeSize=${{ inputs.etcd_volume_size }} \
           --set spec.etcdClusters[*].manager.env=ETCD_QUOTA_BACKEND_BYTES=8589934592 \
           --set spec.kubeAPIServer.enableContentionProfiling=true \

--- a/create-instance-group/action.yaml
+++ b/create-instance-group/action.yaml
@@ -48,6 +48,7 @@ runs:
             --set spec.machineType=${{ inputs.node_size }} \
             --set spec.rootVolume.type=${{ inputs.node_volume_type }} \
             --set spec.rootVolume.size=${{ inputs.node_volume_size }} \
+            --set spec.associatePublicIP=false \
             --unset spec.zones \
             --set spec.zones=us-west1-a
 

--- a/create-instance-group/action.yaml
+++ b/create-instance-group/action.yaml
@@ -38,6 +38,7 @@ runs:
           # and guaranteed to be what we set it to.
           # Otherwise, the value given will be appended to the zone list.
           ./kops edit ig ${{ inputs.ig_name }} \
+            --name ${{ inputs.cluster_name }} \
             --state ${{ inputs.kops_state }} \
             --set spec.maxSize=${{ inputs.node_count }} \
             --set spec.minSize=${{ inputs.node_count }} \
@@ -50,6 +51,7 @@ runs:
       shell: bash
       run: |
           ./kops get instancegroups ${{ inputs.ig_name }} \
+            --name ${{ inputs.cluster_name }} \
             --state ${{ inputs.kops_state }} \
             -o yaml
 

--- a/create-instance-group/action.yaml
+++ b/create-instance-group/action.yaml
@@ -16,6 +16,9 @@ inputs:
   ig_name:
     description: "Name of instanceGroup"
     required: true
+  node_volume_type:
+    description: "Type of the root volume deployed for nodes"
+    default: "pd-standard"
   node_volume_size:
     description: "Size of the root volume deployed for nodes"
     default: "50"
@@ -43,6 +46,7 @@ runs:
             --set spec.maxSize=${{ inputs.node_count }} \
             --set spec.minSize=${{ inputs.node_count }} \
             --set spec.machineType=${{ inputs.node_size }} \
+            --set spec.rootVolume.type=${{ inputs.node_volume_type }} \
             --set spec.rootVolume.size=${{ inputs.node_volume_size }} \
             --unset spec.zones \
             --set spec.zones=us-west1-a


### PR DESCRIPTION
Configure the disk used for the etcd cluster members to be of type pd-ssd, to attain better IOPS performance. Similarly, let's make it possible to configure the disk type of additional instance groups.

According to the comparison provided by the gcloud console, the following is to be expected for a disk of 50GB (attached to an instance with 16 cores):

```
|            | standard  | balanced |  ssd  |
|------------|-----------|----------|-------|
| Read IOPS  |        38 |      300 |  1500 |
| Write IOPS |        75 |      300 | 1,500 |
```

And similarly for a 200GB disk:

```
|            | standard  | balanced |  ssd  |
|------------|-----------|----------|-------|
| Read IOPS  |       150 |    1,200 | 6,000 |
| Write IOPS |       300 |    1,200 | 6,000 |
```

Moreover, let's disable public IPs in the additional instance groups, given that they are not necessary to perform the tests, and lead to increased costs.