### PR TITLE
Fix not pinned ccm image

### DIFF
--- a/create-cluster/action.yaml
+++ b/create-cluster/action.yaml
@@ -92,6 +92,7 @@ runs:
           --set spec.kubeControllerManager.configureCloudRoutes=${{ inputs.sync_cloud_routes }} \
           --set spec.cloudControllerManager.configureCloudRoutes=${{ inputs.sync_cloud_routes }} \
           --set spec.cloudControllerManager.concurrentNodeSyncs=10 \
+          --set spec.cloudControllerManager.image=gcr.io/k8s-staging-cloud-provider-gcp/cloud-controller-manager:v32.2.4 \
           --set spec.kubeScheduler.kubeAPIQPS=500 \
           --set spec.kubeScheduler.kubeAPIBurst=500 \
           --yes"


### PR DESCRIPTION
Until new kops version is released, current versions are affected by the bug that CCM image is not pinned to specific version, but to latest build version instead.
Related PR: https://github.com/kubernetes/kops/pull/17348/
Example run: https://github.com/cilium/cilium/actions/runs/14513591000/job/40717610575