### PR TITLE
Revert "Fix not pinned ccm image"

### DIFF
--- a/create-cluster/action.yaml
+++ b/create-cluster/action.yaml
@@ -92,7 +92,6 @@ runs:
           --set spec.kubeControllerManager.configureCloudRoutes=${{ inputs.sync_cloud_routes }} \
           --set spec.cloudControllerManager.configureCloudRoutes=${{ inputs.sync_cloud_routes }} \
           --set spec.cloudControllerManager.concurrentNodeSyncs=10 \
-          --set spec.cloudControllerManager.image=gcr.io/k8s-staging-cloud-provider-gcp/cloud-controller-manager:v32.2.4 \
           --set spec.kubeScheduler.kubeAPIQPS=500 \
           --set spec.kubeScheduler.kubeAPIBurst=500 \
           --yes"


### PR DESCRIPTION
This reverts commit b83e200cdea7099967b48cdad1d7275b949f7dc0.

Now that a new kops version including the fix has been released and bumped here, we can revert this temporary hack.