### PR TITLE
Revert "Update dependency kubernetes/kops to v1.32.0"

### DIFF
--- a/install-kops/action.yaml
+++ b/install-kops/action.yaml
@@ -5,7 +5,7 @@ inputs:
     description: "version of kops"
     required: true
     # renovate: datasource=github-releases depName=kubernetes/kops
-    default: "v1.32.0"
+    default: "v1.31.0"
 runs:
   using: "composite"
   steps:


### PR DESCRIPTION
This reverts commit 78bb519429918502277215d6a6a9b1269f3e3aec.
Seems like scale-100 test is having problems, while it works with kops 1.31:  https://github.com/cilium/cilium/actions/runs/15733615323/attempts/1