### PR TITLE
workaround: fix coredns provisioning issue on kops 1.33

### DIFF
--- a/create-cluster/action.yaml
+++ b/create-cluster/action.yaml
@@ -126,3 +126,22 @@ runs:
       shell: bash
       run: |
         until kubectl get nodes; do sleep 45s; done
+
+    # Issue: https://github.com/cilium/cilium/issues/41313
+    - name: Hack until kops fixes their issue
+      shell: bash
+      run: |
+        cat <<EOF | kubectl apply -f -
+        apiVersion: v1
+        kind: ConfigMap
+        metadata:
+          name: coredns-autoscaler
+          namespace: kube-system
+        data:
+          linear: |-
+            {
+              "coresPerReplica": 256,
+              "nodesPerReplica": 16,
+              "preventSinglePointFailure": false,
+            }
+        EOF


### PR DESCRIPTION
Due to new topologySpreadConstraints for coredns in kops, coredns is not able to start 2 coredns pods on 1 control plane + 1 worker node cluster. By default, `preventSinglePointFailure` is true

Confirmed it works here: https://github.com/cilium/cilium/actions/runs/17127450448/job/48582489426
Related: https://github.com/cilium/cilium/issues/41313