### PR TITLE
create-instance-group: specify zone

### DIFF
--- a/create-instance-group/action.yaml
+++ b/create-instance-group/action.yaml
@@ -1,5 +1,5 @@
 name: 'Add new Instance Group to cluster'
-description: "Workflow that cleans up kops cluster"
+description: "Workflow that creates a kops instance group"
 inputs:
   cluster_name:
     description: "Name of the cluster"
@@ -32,7 +32,8 @@ runs:
             --role node \
             --name ${{ inputs.cluster_name }} \
             --state ${{ inputs.kops_state }} \
-            --edit=false
+            --edit=false \
+            --zone us-west1-a
 
     - name: Edit Instance Group parameters
       shell: bash


### PR DESCRIPTION
This is needed for GCE clusters, and currently causes the scale workflows to fail (see [0]). Match the hard-coded zone name from further down in the action.

[0]: https://github.com/cilium/cilium/actions/runs/25479443167/job/74760110288#step:20:96